### PR TITLE
Payment creation methods

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -38,24 +38,28 @@ class Loan < ApplicationRecord
     all.joins(:payments).where('payments.due_date < ?',DateTime.now).where(payments: { paid: false })
   end
 
+
+  # This method is used to create the payments which are shown to the user before confirming/accepting the loan
   def create_payments_proposed
     payment_amount = ((proposed_amount.amount * (1 + interest_rate.fdiv(100))) / duration_months) * 100
 
     counter = 1
     duration_months.times do
-      payment = payments.build(amount_cents: payment_amount, due_date: (DateTime.now + counter.month))
+      payment = payments.build(amount_cents: payment_amount, due_date: (DateTime.now + counter.month)) # DateTime.now used as start_date will be set later
       payment.save
       counter += 1
     end
   end
 
+  # This method is used to create the final payments based on the agreed amount which is entered by the user
+  # Old payments are destroyed and replaced by new ones based on this new amount
   def update_payments_to_agreed_amount
     payments.destroy_all
 
     payment_amount = ((agreed_amount.amount * (1 + interest_rate.fdiv(100))) / duration_months) * 100
     counter = 1
     duration_months.times do
-      payment = payments.build(amount_cents: payment_amount, due_date: (DateTime.now + counter.month))
+      payment = payments.build(amount_cents: payment_amount, due_date: (start_date + counter.month))
       payment.save
       counter += 1
     end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -37,4 +37,27 @@ class Loan < ApplicationRecord
   def self.delayed_payment_loans
     all.joins(:payments).where('payments.due_date < ?',DateTime.now).where(payments: { paid: false })
   end
+
+  def create_payments_proposed
+    payment_amount = ((proposed_amount.amount * (1 + interest_rate.fdiv(100))) / duration_months) * 100
+
+    counter = 1
+    duration_months.times do
+      payment = payments.build(amount_cents: payment_amount, due_date: (DateTime.now + counter.month))
+      payment.save
+      counter += 1
+    end
+  end
+
+  def update_payments_to_agreed_amount
+    payments.destroy_all
+
+    payment_amount = ((agreed_amount.amount * (1 + interest_rate.fdiv(100))) / duration_months) * 100
+    counter = 1
+    duration_months.times do
+      payment = payments.build(amount_cents: payment_amount, due_date: (DateTime.now + counter.month))
+      payment.save
+      counter += 1
+    end
+  end
 end

--- a/db/migrate/20161123120623_add_duration_months_to_loans.rb
+++ b/db/migrate/20161123120623_add_duration_months_to_loans.rb
@@ -1,0 +1,5 @@
+class AddDurationMonthsToLoans < ActiveRecord::Migration[5.0]
+  def change
+    add_column :loans, :duration_months, :integer, default: 3
+  end
+end

--- a/db/migrate/20161123132057_add_decline_reason_to_loans.rb
+++ b/db/migrate/20161123132057_add_decline_reason_to_loans.rb
@@ -1,0 +1,5 @@
+class AddDeclineReasonToLoans < ActiveRecord::Migration[5.0]
+  def change
+    add_column :loans, :decline_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123120623) do
+ActiveRecord::Schema.define(version: 20161123132057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20161123120623) do
     t.integer  "proposed_amount_cents",  default: 0, null: false
     t.integer  "agreed_amount_cents",    default: 0, null: false
     t.integer  "duration_months",        default: 3
+    t.string   "decline_reason"
     t.index ["bank_id"], name: "index_loans_on_bank_id", using: :btree
     t.index ["user_id"], name: "index_loans_on_user_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161122142352) do
+ActiveRecord::Schema.define(version: 20161123120623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20161122142352) do
     t.integer  "requested_amount_cents", default: 0, null: false
     t.integer  "proposed_amount_cents",  default: 0, null: false
     t.integer  "agreed_amount_cents",    default: 0, null: false
+    t.integer  "duration_months",        default: 3
     t.index ["bank_id"], name: "index_loans_on_bank_id", using: :btree
     t.index ["user_id"], name: "index_loans_on_user_id", using: :btree
   end


### PR DESCRIPTION
2 methods added to loan model

1. create_payment_methods -> This is to be used on the bank's side to create temporary payments which can be shown to the user before he confirms

2. update_payments_to_agreed_amount -> This is to be used on the user's side after confirming the loan. It destroys the old temporary payments and replaces them with new one's with the correct amount.